### PR TITLE
Fix rotation yaw in compass element

### DIFF
--- a/src/main/java/net/spellcraftgaming/rpghud/gui/hud/element/modern/HudElementCompassModern.java
+++ b/src/main/java/net/spellcraftgaming/rpghud/gui/hud/element/modern/HudElementCompassModern.java
@@ -29,7 +29,7 @@ public class HudElementCompassModern extends HudElementCompassVanilla {
 		int posY = getPosY(scaledHeight);
 		int swapSides = this.settings.getBoolValue(Settings.invert_compass) ? -1 : 1;
 
-		int rotation = Math.round(((this.mc.player.rotationYaw % 360) / 360) * 200);
+		int rotation = Math.round(((this.mc.gameRenderer.getActiveRenderInfo().getYaw() % 360) / 360) * 200);
 		if (rotation < 0)
 			rotation = 200 + rotation;
 		drawRect(posX - 50, posY + 2, 100, 6, 0xAA000000);

--- a/src/main/java/net/spellcraftgaming/rpghud/gui/hud/element/vanilla/HudElementCompassVanilla.java
+++ b/src/main/java/net/spellcraftgaming/rpghud/gui/hud/element/vanilla/HudElementCompassVanilla.java
@@ -30,7 +30,7 @@ public class HudElementCompassVanilla extends HudElement {
 		int width = scaledWidth / 2 + this.settings.getPositionValue(Settings.compass_position)[0];
 		int posY = this.settings.getPositionValue(Settings.compass_position)[1];
 		int swapSides = this.settings.getBoolValue(Settings.invert_compass) ? -1 : 1;
-		int rotation = Math.round(((this.mc.player.rotationYaw % 360) / 360) * 200);
+		int rotation = Math.round(((this.mc.gameRenderer.getActiveRenderInfo().getYaw() % 360) / 360) * 200);
 		if (rotation < 0)
 			rotation = 200 + rotation;
 


### PR DESCRIPTION
It will be better to use yaw from active render info. In some cases real camera yaw can be different from player yaw (with mirrored third person mode).